### PR TITLE
Allow writable? in customField spec double

### DIFF
--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -63,6 +63,7 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     before do
       allow(schema).to receive(:assignable_values).with(:version, anything).and_return(versions)
+      allow(schema).to receive(:writable?).and_return(true)
     end
 
     describe 'basic custom field' do


### PR DESCRIPTION
Fixes unexpected messages in the custom field specs. Note that `writable: true` is required for some of the specs to succeed.