### PR TITLE
Implement API V3 companies resource

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,0 +1,7 @@
+class Company < ApplicationRecord
+  belongs_to :owner, class_name: 'User'
+
+  def owning_users
+    [owner]
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,53 @@
 class Company < ApplicationRecord
   belongs_to :owner, class_name: 'User'
 
+  has_many :issued_shares, -> { where(active: true) }, foreign_key: 'child_id', inverse_of: :child, class_name: 'Share'
+  has_many :parents, through: :issued_shares
+
+  has_many :owned_shares, -> { where(active: true) }, foreign_key: 'parent_id', inverse_of: :parent, class_name: 'Share'
+  has_many :children, through: :owned_shares
+
+  # The set of owning users are those users, that are owners of companies,
+  # which are parents (or any ancestor) to the company being represented.
+  #
+  # Those owners then overrule any owner directly linked to the represented
+  # company. This overruling takes place on every level of ancestry.
+  #
+  # E.g. In a set of companies
+  #
+  # grandparent - (owner A)
+  # parent - (owner B)
+  # child - (owner C)
+  #
+  # the owning user of child is A.
+  #
+  # The overruling only takes place if the share is active.
+  # So in the example above, with the share between parent and grandparent not
+  # being active, the owning user of child would be B.
+  #
+  # If a company has no parent or only has parents on inactive shares, the
+  # owning user is the user of the company. Referring to the example again, if
+  # the share between child and parent were to be inactive (or to not exist at
+  # all), the owning user of child would be C.
+  #
+  # Since a company can have multiple parents, there can also be multiple owning
+  # users
+  #
+  # E.g. in a set of companies
+  #
+  #                                  grandgrandparent 1 (parent to grandparent 2) - (owner A)
+  # grandparent 1 - (owner B)        grandparent 2 - (owner C)
+  #                  parent - (owner D)
+  #                  child - (owner E)
+  #
+  # assuming that every share is active, the owning users of child would be A and B.
   def owning_users
-    [owner]
+    @owning_users ||= begin
+      return [owner] if parents.none?
+
+      parents.map do |parent|
+        parent.owning_users
+      end.flatten
+    end
   end
 end

--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -1,0 +1,4 @@
+class Share < ApplicationRecord
+  belongs_to :parent, class_name: 'Company'
+  belongs_to :child, class_name: 'Company'
+end

--- a/db/migrate/20220204124318_create_companies.rb
+++ b/db/migrate/20220204124318_create_companies.rb
@@ -1,0 +1,10 @@
+class CreateCompanies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :companies do |t|
+      t.string :name
+      t.references :owner, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220204170526_create_shares.rb
+++ b/db/migrate/20220204170526_create_shares.rb
@@ -1,0 +1,11 @@
+class CreateShares < ActiveRecord::Migration[6.1]
+  def change
+    create_table :shares do |t|
+      t.boolean :active
+      t.references :parent, null: false, foreign_key: { to_table: :companies }, index: true
+      t.references :child, null: false, foreign_key: { to_table: :companies }, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/api/v3/companies/companies_api.rb
+++ b/lib/api/v3/companies/companies_api.rb
@@ -1,0 +1,69 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Companies
+      class CompaniesAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::PageSizeHelper
+
+        resources :companies do
+          get do
+            query = ParamsToQueryService
+                    .new(::Company, current_user)
+                    .call(params)
+
+            if query.valid?
+              CompanyCollectionRepresenter.new(query.results,
+                                               self_link: api_v3_paths.companies,
+                                               page: to_i_or_nil(params[:offset]),
+                                               per_page: resolve_page_size(params[:pageSize]),
+                                               current_user: current_user)
+            else
+              raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+            end
+          end
+
+          route_param :id, type: Integer, desc: 'Company ID' do
+            after_validation do
+              @company = ::Company.find(params[:id])
+            end
+
+            get do
+              CompanyRepresenter.create(@company,
+                                        current_user: current_user,
+                                        embed_links: true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/companies/company_collection_representer.rb
+++ b/lib/api/v3/companies/company_collection_representer.rb
@@ -1,0 +1,38 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Fouwndation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Companies
+      class CompanyCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+      end
+    end
+  end
+end

--- a/lib/api/v3/companies/company_representer.rb
+++ b/lib/api/v3/companies/company_representer.rb
@@ -1,0 +1,55 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Gen eral Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Companies
+      class CompanyRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::Decorators::DateProperty
+
+        self_link title_getter: ->(*) { represented.name }
+
+        property :id
+
+        property :name
+
+        date_time_property :created_at
+        date_time_property :updated_at
+
+        associated_resources :owning_users,
+                             v3_path: :user,
+                             representer: ::API::V3::Users::UserRepresenter
+
+        def _type
+          'Company'
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -76,6 +76,7 @@ module API
       mount ::API::V3::WorkPackages::WorkPackagesAPI
       mount ::API::V3::WikiPages::WikiPagesAPI
       mount ::API::V3::Grids::GridsAPI
+      mount ::API::V3::Companies::CompaniesAPI
 
       get '/' do
         RootRepresenter.new({}, current_user: current_user)

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -178,6 +178,9 @@ module API
             "#{project(id)}/categories"
           end
 
+          index :company
+          show :company
+
           def self.configuration
             "#{root}/configuration"
           end


### PR DESCRIPTION
## What I did

This PR implements the bare minimum requirements as described in the exercise, that is:

* A new `companies` resource 
* A working  `owningUses` endpoint 

However, the naive implementation strategy I used for the `owningUsers` endpoint is enough to pass the tests and might cater to very simple scenarios where the number of companies is low, but it definitely won't scale well.

## Problem 

The relationship we're modeling can be seen as a **Directed Acyclic Graph**, with `Share` instances being the _edges_, and `Company` instances being _nodes_ (or _vertexes_). 

The `owningUsers` endpoint needs to calculate the _ancestors_ of the company which also are _root_ nodes (i.e. nodes that have no parents).

The current implementation (essentially, an adjacency list) is inefficient, as it needs to traverse the whole ancestor's tree recursively and query the DB with each iteration.

<details><summary>See example of generated queries</summary>

```
> Company.first.owning_users
# Company Load (0.7ms)  SELECT "companies".* FROM "companies" ORDER BY "companies"."id" ASC LIMIT $1  [["LIMIT", 1]]
# Company Exists? (0.7ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 1], ["active", true], ["LIMIT", 1]]
# Company Load (0.5ms)  SELECT "companies".* FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2  [["child_id", 1], ["active", true]]
# Company Exists? (0.5ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 2], ["active", true], ["LIMIT", 1]]
# Company Load (0.3ms)  SELECT "companies".* FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2  [["child_id", 2], ["active", true]]
# Company Exists? (0.7ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 4], ["active", true], ["LIMIT", 1]]
# Company Load (0.3ms)  SELECT "companies".* FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2  [["child_id", 4], ["active", true]]
# Company Exists? (0.4ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 6], ["active", true], ["LIMIT", 1]]
# User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."type" IN ($1, $2) AND "users"."id" = $3 LIMIT $4  [["type", "User"], ["type", "AnonymousUser"], ["id", 7], ["LIMIT", 1]]
# Company Exists? (0.4ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 7], ["active", true], ["LIMIT", 1]]
# Company Load (0.2ms)  SELECT "companies".* FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2  [["child_id", 7], ["active", true]]
# Company Exists? (0.5ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 10], ["active", true], ["LIMIT", 1]]
# User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."type" IN ($1, $2) AND "users"."id" = $3 LIMIT $4  [["type", "User"], ["type", "AnonymousUser"], ["id", 11], ["LIMIT", 1]]
# Company Exists? (0.4ms)  SELECT 1 AS one FROM "companies" INNER JOIN "shares" ON "companies"."id" = "shares"."parent_id" WHERE "shares"."child_id" = $1 AND "shares"."active" = $2 LIMIT $3  [["child_id", 11], ["active", true], ["LIMIT", 1]]
# User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."type" IN ($1, $2) AND "users"."id" = $3 LIMIT $4  [["type", "User"], ["type", "AnonymousUser"], ["id", 12], ["LIMIT", 1]]
```

</details>

## Suggested alternative approach

An alternative, more efficient approach to calculate `owningUsers` would leverage the [`ltree`](https://www.postgresql.org/docs/current/ltree.html) extension provided by PostgreSQL to implement the _Materialized Paths_ pattern, which consists in storing full representations of the lineage path of every node as strings in a dedicated column. 

E.g. given a graph of companies:

![OpenProject-graph drawio](https://user-images.githubusercontent.com/66493/152799019-dbd7205f-df73-4646-99fb-befeb892fe26.png)

We would store the following paths for company `E` in the DB:

company | path
--|--
E | A.C.D.E
E | B.D.E

This would allow us to perform simple string-based queries on the `path` column.

On the other hand, **PostgreSQL's `ltree` extension**  provides a `ltree` data type, along with its own specialized operators and index types, which are perfectly suited for the implementation of this pattern, e.g.:

* The `nlevel` function returns the number of levels in a given path. The paths for a root node has a `nlevel` of `1` because it only contains the root node itself (doesn't have any ancestors, thus there's no lineage), so this query would return all root nodes in the graph:

  ```sql
  SELECT * FROM paths
  WHERE nlevel(path) = 1;
  ```

* The `<@` operator, when used with `ltree` columns, tests whether one path is a descendant of another, so this query would return all ancestors of company E:
  
  ```sql
  SELECT * from paths
  WHERE 'E' <@ path;
  ```

With all that in mind, we could create a `paths` table such as this:

Column name | Type 
---|---
id | integer
company_id | integer
path | ltree

_A GiST index should be added to the `path` column._

Then we could find a company's owning companies with a query such as this:

```sql
SELECT company_id from paths
WHERE nlevel(path) = 1
AND '5' <@ path
```

Which would return all ancestors of the `Company` with id `5` that have no parent companies. We could then easily expand the query to retrieve the owners of those companies.

(Please note that this query hasn't been tested and is used just for illustration purposes.)

### Caveats

* Whenever a `Share` is created, activated, disabled or deleted, we'll need to take care of recalculating the affected paths. Implementing this recalculation is probably the most complex part of the solution, and I've left it out of the scope of this analysis, but the topic is discussed [here](https://www.bustawin.com/dags-with-materialized-paths-using-postgres-ltree/) and an implementation of both an `add_edge` and a `delete_edge` SQL function can be found [here](https://github.com/eReuse/devicehub-teal/blob/master/ereuse_devicehub/resources/lot/dag.sql).
* While the performance of _read_ operations would be dramatically improved with this approach,  the cost of _write_ operations will be increased, since we'll have to update the `paths` table when the graph changes.
* The proposed approach assumes all the required conditions (privileges, etc) to install the `ltree` PostgreSQL extension in our DB server are met.

## References

Further reading that could be useful for inspiration of reference:

 * [Nested Sets and Materialized Path SQL Trees](http://www.rampant-books.com/art_vadim_nested_sets_sql_trees.htm)
* [PostgreSQL documentation for `ltree`](https://www.postgresql.org/docs/current/ltree.html)
* [DAGs with materialized paths using postgres ltree
](https://www.bustawin.com/dags-with-materialized-paths-using-postgres-ltree/)

